### PR TITLE
Remove discord verification file

### DIFF
--- a/.well-known/discord.html
+++ b/.well-known/discord.html
@@ -1,1 +1,0 @@
-dh=307f29e05c4beb4ba92afad7a62eea75f0664380


### PR DESCRIPTION
Deleted .well-known/discord.html, which was likely used for Discord domain verification and is no longer needed.